### PR TITLE
[Fix/#73] 닉네임 영문 허용

### DIFF
--- a/app/src/main/java/com/swyp/firsttodo/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/onboarding/OnboardingViewModel.kt
@@ -30,13 +30,13 @@ class OnboardingViewModel
 
         private var lastBackPressTime = 0L
 
-        private val validNicknameRegex = Regex("^[가-힣]{1,12}$")
+        private val validNicknameRegex = Regex("^[가-힣a-zA-Z]{1,12}$")
 
         init {
             snapshotFlow { nickNameFieldState.text.toString() }
                 .onEach { nickname ->
                     val errorText = if (nickname.isNotEmpty() && !isValidNickname(nickname)) {
-                        "닉네임은 1~12자의 한글만 사용해 주세요."
+                        "닉네임은 1~12자의 한글 또는 영문만 사용해 주세요."
                     } else {
                         null
                     }

--- a/app/src/main/java/com/swyp/firsttodo/presentation/onboarding/component/ProfileView.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/onboarding/component/ProfileView.kt
@@ -36,7 +36,7 @@ fun ProfileView(
         )
 
         Text(
-            text = "한글 최대 12자 / 영문, 숫자, 특수기호 불가",
+            text = "최대 12자 / 숫자, 공백, 특수기호 불가",
             modifier = Modifier.padding(bottom = 56.dp),
             color = HaebomTheme.colors.gray300,
             textAlign = TextAlign.Center,


### PR DESCRIPTION
## Related issue 🛠️
- closed #73 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- ui 문구 수정
- 정규식 수정

## Uncompleted Tasks 😅
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 프로필 닉네임 입력 시 한글과 영문 문자를 모두 지원합니다.
  * 입력 제약 사항 안내 메시지가 업데이트되었습니다 (최대 12자).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->