### PR TITLE
[Feat/#83] 습관 재도전 API 연동

### DIFF
--- a/app/src/main/java/com/swyp/firsttodo/data/mapper/HabitMapper.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/mapper/HabitMapper.kt
@@ -1,7 +1,7 @@
 package com.swyp.firsttodo.data.mapper
 
+import com.swyp.firsttodo.data.remote.dto.response.habit.HabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseDto
-import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseListDto
 import com.swyp.firsttodo.domain.model.habit.HabitDuration
 import com.swyp.firsttodo.domain.model.habit.HabitModel
 
@@ -17,4 +17,4 @@ fun HabitResponseDto.toModel(): HabitModel =
         isCompleted = isCompleted,
     )
 
-fun HabitResponseListDto.toModel(): List<HabitModel> = habits.map { it.toModel() }
+fun HabitListResponseDto.toModel(): List<HabitModel> = habits.map { it.toModel() }

--- a/app/src/main/java/com/swyp/firsttodo/data/mapper/HabitMapper.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/mapper/HabitMapper.kt
@@ -1,5 +1,7 @@
 package com.swyp.firsttodo.data.mapper
 
+import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitListResponseDto
+import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseDto
 import com.swyp.firsttodo.domain.model.habit.HabitDuration
@@ -17,4 +19,15 @@ fun HabitResponseDto.toModel(): HabitModel =
         isCompleted = isCompleted,
     )
 
+fun FailedHabitResponseDto.toModel(): HabitModel =
+    HabitModel(
+        habitId = habitId,
+        title = title,
+        duration = duration.toHabitDuration(),
+        reward = reward,
+        isCompleted = true,
+    )
+
 fun HabitListResponseDto.toModel(): List<HabitModel> = habits.map { it.toModel() }
+
+fun FailedHabitListResponseDto.toModel(): List<HabitModel> = failedHabits.map { it.toModel() }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/datasource/HabitDataSource.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/datasource/HabitDataSource.kt
@@ -1,6 +1,7 @@
 package com.swyp.firsttodo.data.remote.datasource
 
 import com.swyp.firsttodo.core.network.model.BaseResponse
+import com.swyp.firsttodo.data.remote.dto.request.habit.FailedHabitRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitListResponseDto
@@ -20,4 +21,9 @@ interface HabitDataSource {
     suspend fun getHabitList(): BaseResponse<HabitListResponseDto>
 
     suspend fun getFailedHabitList(): BaseResponse<FailedHabitListResponseDto>
+
+    suspend fun patchFailedHabit(
+        habitId: Long,
+        request: FailedHabitRequestDto,
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/datasource/HabitDataSource.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/datasource/HabitDataSource.kt
@@ -3,8 +3,8 @@ package com.swyp.firsttodo.data.remote.datasource
 import com.swyp.firsttodo.core.network.model.BaseResponse
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
+import com.swyp.firsttodo.data.remote.dto.response.habit.HabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseDto
-import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseListDto
 
 interface HabitDataSource {
     suspend fun postHabit(request: HabitPostRequestDto): BaseResponse<HabitResponseDto>
@@ -16,5 +16,5 @@ interface HabitDataSource {
 
     suspend fun deleteHabit(habitId: Long): BaseResponse<Unit>
 
-    suspend fun getHabitList(): BaseResponse<HabitResponseListDto>
+    suspend fun getHabitList(): BaseResponse<HabitListResponseDto>
 }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/datasource/HabitDataSource.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/datasource/HabitDataSource.kt
@@ -3,6 +3,7 @@ package com.swyp.firsttodo.data.remote.datasource
 import com.swyp.firsttodo.core.network.model.BaseResponse
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
+import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseDto
 
@@ -17,4 +18,6 @@ interface HabitDataSource {
     suspend fun deleteHabit(habitId: Long): BaseResponse<Unit>
 
     suspend fun getHabitList(): BaseResponse<HabitListResponseDto>
+
+    suspend fun getFailedHabitList(): BaseResponse<FailedHabitListResponseDto>
 }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/datasourceimpl/HabitDataSourceImpl.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/datasourceimpl/HabitDataSourceImpl.kt
@@ -4,8 +4,8 @@ import com.swyp.firsttodo.core.network.model.BaseResponse
 import com.swyp.firsttodo.data.remote.datasource.HabitDataSource
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
+import com.swyp.firsttodo.data.remote.dto.response.habit.HabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseDto
-import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseListDto
 import com.swyp.firsttodo.data.remote.service.HabitService
 import javax.inject.Inject
 
@@ -28,5 +28,5 @@ class HabitDataSourceImpl
 
         override suspend fun deleteHabit(habitId: Long): BaseResponse<Unit> = habitService.deleteHabit(habitId)
 
-        override suspend fun getHabitList(): BaseResponse<HabitResponseListDto> = habitService.getHabitList()
+        override suspend fun getHabitList(): BaseResponse<HabitListResponseDto> = habitService.getHabitList()
     }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/datasourceimpl/HabitDataSourceImpl.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/datasourceimpl/HabitDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.swyp.firsttodo.core.network.model.BaseResponse
 import com.swyp.firsttodo.data.remote.datasource.HabitDataSource
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
+import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseDto
 import com.swyp.firsttodo.data.remote.service.HabitService
@@ -29,4 +30,7 @@ class HabitDataSourceImpl
         override suspend fun deleteHabit(habitId: Long): BaseResponse<Unit> = habitService.deleteHabit(habitId)
 
         override suspend fun getHabitList(): BaseResponse<HabitListResponseDto> = habitService.getHabitList()
+
+        override suspend fun getFailedHabitList(): BaseResponse<FailedHabitListResponseDto> =
+            habitService.getFailedHabitList()
     }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/datasourceimpl/HabitDataSourceImpl.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/datasourceimpl/HabitDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.swyp.firsttodo.data.remote.datasourceimpl
 
 import com.swyp.firsttodo.core.network.model.BaseResponse
 import com.swyp.firsttodo.data.remote.datasource.HabitDataSource
+import com.swyp.firsttodo.data.remote.dto.request.habit.FailedHabitRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitListResponseDto
@@ -33,4 +34,9 @@ class HabitDataSourceImpl
 
         override suspend fun getFailedHabitList(): BaseResponse<FailedHabitListResponseDto> =
             habitService.getFailedHabitList()
+
+        override suspend fun patchFailedHabit(
+            habitId: Long,
+            request: FailedHabitRequestDto,
+        ): BaseResponse<Unit> = habitService.patchFailedHabit(habitId, request)
     }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/dto/request/habit/FailedHabitRequestDto.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/dto/request/habit/FailedHabitRequestDto.kt
@@ -1,0 +1,12 @@
+package com.swyp.firsttodo.data.remote.dto.request.habit
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FailedHabitRequestDto(
+    @SerialName("duration")
+    val duration: String,
+    @SerialName("reward")
+    val reward: String?,
+)

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/dto/response/habit/FailedHabitResponseDto.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/dto/response/habit/FailedHabitResponseDto.kt
@@ -1,0 +1,22 @@
+package com.swyp.firsttodo.data.remote.dto.response.habit
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FailedHabitListResponseDto(
+    @SerialName("failedHabits")
+    val failedHabits: List<FailedHabitResponseDto>,
+)
+
+@Serializable
+data class FailedHabitResponseDto(
+    @SerialName("habitId")
+    val habitId: Long,
+    @SerialName("title")
+    val title: String,
+    @SerialName("duration")
+    val duration: String,
+    @SerialName("reward")
+    val reward: String?,
+)

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/dto/response/habit/HabitResponseDto.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/dto/response/habit/HabitResponseDto.kt
@@ -4,6 +4,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class HabitListResponseDto(
+    @SerialName("habits")
+    val habits: List<HabitResponseDto>,
+)
+
+@Serializable
 data class HabitResponseDto(
     @SerialName("habitId")
     val habitId: Long,
@@ -15,10 +21,4 @@ data class HabitResponseDto(
     val reward: String?,
     @SerialName("isCompleted")
     val isCompleted: Boolean,
-)
-
-@Serializable
-data class HabitResponseListDto(
-    @SerialName("habits")
-    val habits: List<HabitResponseDto>,
 )

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/service/HabitService.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/service/HabitService.kt
@@ -3,8 +3,9 @@ package com.swyp.firsttodo.data.remote.service
 import com.swyp.firsttodo.core.network.model.BaseResponse
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
+import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitListResponseDto
+import com.swyp.firsttodo.data.remote.dto.response.habit.HabitListResponseDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseDto
-import com.swyp.firsttodo.data.remote.dto.response.habit.HabitResponseListDto
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -30,5 +31,8 @@ interface HabitService {
     ): BaseResponse<Unit>
 
     @GET("/api/v1/habits")
-    suspend fun getHabitList(): BaseResponse<HabitResponseListDto>
+    suspend fun getHabitList(): BaseResponse<HabitListResponseDto>
+
+    @GET("/api/v1/habits/failed")
+    suspend fun getFailedHabitList(): BaseResponse<FailedHabitListResponseDto>
 }

--- a/app/src/main/java/com/swyp/firsttodo/data/remote/service/HabitService.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/remote/service/HabitService.kt
@@ -1,6 +1,7 @@
 package com.swyp.firsttodo.data.remote.service
 
 import com.swyp.firsttodo.core.network.model.BaseResponse
+import com.swyp.firsttodo.data.remote.dto.request.habit.FailedHabitRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
 import com.swyp.firsttodo.data.remote.dto.response.habit.FailedHabitListResponseDto
@@ -35,4 +36,10 @@ interface HabitService {
 
     @GET("/api/v1/habits/failed")
     suspend fun getFailedHabitList(): BaseResponse<FailedHabitListResponseDto>
+
+    @PATCH("/api/v1/habits/failed/{habitId}/status/in-progress")
+    suspend fun patchFailedHabit(
+        @Path("habitId") habitId: Long,
+        @Body request: FailedHabitRequestDto,
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/swyp/firsttodo/data/repositoryimpl/HabitRepositoryImpl.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/repositoryimpl/HabitRepositoryImpl.kt
@@ -92,4 +92,9 @@ class HabitRepositoryImpl
             apiResponseHandler.safeApiCall {
                 habitDataSource.getHabitList()
             }.map { it.toModel() }
+
+        override suspend fun getFailedHabits(): Result<List<HabitModel>> =
+            apiResponseHandler.safeApiCall {
+                habitDataSource.getFailedHabitList()
+            }.map { it.toModel() }
     }

--- a/app/src/main/java/com/swyp/firsttodo/data/repositoryimpl/HabitRepositoryImpl.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/repositoryimpl/HabitRepositoryImpl.kt
@@ -112,14 +112,18 @@ class HabitRepositoryImpl
                         reward = reward,
                     ),
                 )
-            }.fold(
-                onSuccess = { Result.success(Unit) },
-                onFailure = { throwable ->
-                    val error = when (throwable) {
+            }.map { it }
+                .recoverCatching { throwable ->
+                    throw when (throwable) {
+                        is ApiError.BadRequest -> if (throwable.code == 40022) {
+                            HabitError.RewardEmpty(
+                                throwable.serverMsg,
+                            )
+                        } else {
+                            throwable
+                        }
                         is ApiError.NotFound -> HabitError.HabitNotFound(throwable.serverMsg)
                         else -> throwable
                     }
-                    Result.failure(error)
-                },
-            )
+                }
     }

--- a/app/src/main/java/com/swyp/firsttodo/data/repositoryimpl/HabitRepositoryImpl.kt
+++ b/app/src/main/java/com/swyp/firsttodo/data/repositoryimpl/HabitRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.swyp.firsttodo.core.network.model.ApiError
 import com.swyp.firsttodo.core.network.util.ApiResponseHandler
 import com.swyp.firsttodo.data.mapper.toModel
 import com.swyp.firsttodo.data.remote.datasource.HabitDataSource
+import com.swyp.firsttodo.data.remote.dto.request.habit.FailedHabitRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPatchRequestDto
 import com.swyp.firsttodo.data.remote.dto.request.habit.HabitPostRequestDto
 import com.swyp.firsttodo.domain.model.habit.HabitDuration
@@ -97,4 +98,28 @@ class HabitRepositoryImpl
             apiResponseHandler.safeApiCall {
                 habitDataSource.getFailedHabitList()
             }.map { it.toModel() }
+
+        override suspend fun retryFailedHabit(
+            habitId: Long,
+            duration: HabitDuration,
+            reward: String?,
+        ): Result<Unit> =
+            apiResponseHandler.safeApiCall {
+                habitDataSource.patchFailedHabit(
+                    habitId = habitId,
+                    request = FailedHabitRequestDto(
+                        duration = duration.name,
+                        reward = reward,
+                    ),
+                )
+            }.fold(
+                onSuccess = { Result.success(Unit) },
+                onFailure = { throwable ->
+                    val error = when (throwable) {
+                        is ApiError.NotFound -> HabitError.HabitNotFound(throwable.serverMsg)
+                        else -> throwable
+                    }
+                    Result.failure(error)
+                },
+            )
     }

--- a/app/src/main/java/com/swyp/firsttodo/domain/repository/HabitRepository.kt
+++ b/app/src/main/java/com/swyp/firsttodo/domain/repository/HabitRepository.kt
@@ -21,4 +21,6 @@ interface HabitRepository {
     suspend fun deleteHabit(habitId: Long): Result<Unit>
 
     suspend fun getHabits(): Result<List<HabitModel>>
+
+    suspend fun getFailedHabits(): Result<List<HabitModel>>
 }

--- a/app/src/main/java/com/swyp/firsttodo/domain/repository/HabitRepository.kt
+++ b/app/src/main/java/com/swyp/firsttodo/domain/repository/HabitRepository.kt
@@ -23,4 +23,10 @@ interface HabitRepository {
     suspend fun getHabits(): Result<List<HabitModel>>
 
     suspend fun getFailedHabits(): Result<List<HabitModel>>
+
+    suspend fun retryFailedHabit(
+        habitId: Long,
+        duration: HabitDuration,
+        reward: String?,
+    ): Result<Unit>
 }

--- a/app/src/main/java/com/swyp/firsttodo/domain/throwable/HabitError.kt
+++ b/app/src/main/java/com/swyp/firsttodo/domain/throwable/HabitError.kt
@@ -10,4 +10,6 @@ sealed class HabitError(
     class CompletedEmpty(message: String) : HabitError(message) // isCompleted 값이 없음
 
     class HabitNotFound(message: String) : HabitError(message) // 해당하는 습관 없음
+
+    class RewardEmpty(message: String) : HabitError(message) // 자녀가 reward를 입력하지 않음
 }

--- a/app/src/main/java/com/swyp/firsttodo/presentation/common/component/HaebomDeleteDialog.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/common/component/HaebomDeleteDialog.kt
@@ -49,6 +49,11 @@ sealed class DeleteDialogType(
         description = "입력한 습관이 사라져요!",
     )
 
+    data object FailedHabit : DeleteDialogType(
+        title = "실패한 습관을 삭제할까요?",
+        description = "실패한 습관이 사라져요!",
+    )
+
     class Disconnect(nickname: String) : DeleteDialogType(
         title = "${nickname}님과의 연결을 끊을까요?",
         description = "연동이 끊기면 ${nickname}님의\n활동을 볼 수 없습니다.",

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailContract.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailContract.kt
@@ -58,6 +58,11 @@ data class HabitDetailUiState(
         HabitDetailScreenState.EDIT -> "수정하기"
         HabitDetailScreenState.RETRY -> "재도전하기"
     }
+
+    val titleEnabled = when (screenState) {
+        HabitDetailScreenState.CREATE, HabitDetailScreenState.EDIT -> true
+        else -> false
+    }
 }
 
 sealed interface HabitDetailSideEffect : UiEffect {

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailScreen.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailScreen.kt
@@ -129,7 +129,7 @@ fun HabitDetailScreen(
 
             TaskInputSection(
                 title = "습관 작성",
-                modifier = Modifier.padding(bottom = 28.dp),
+                modifier = Modifier.padding(bottom = 3.dp),
                 description = uiState.habitDescription,
             ) {
                 HaebomMultiLineTextField(

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailScreen.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailScreen.kt
@@ -146,6 +146,7 @@ fun HabitDetailScreen(
                     } else {
                         null
                     },
+                    enabled = uiState.titleEnabled,
                 )
             }
 

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailViewModel.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailViewModel.kt
@@ -215,9 +215,12 @@ class HabitDetailViewModel
         }
 
         private fun retryHabit() {
+            if (uiState.value.loadingState is Async.Loading) return
             val habitId = uiState.value.habitId ?: return
             val inputDuration = uiState.value.duration ?: return
             val inputReward = rewardState.text.toString()
+
+            updateState { copy(loadingState = Async.Loading()) }
 
             viewModelScope.launch {
                 habitRepository.retryFailedHabit(

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailViewModel.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailViewModel.kt
@@ -215,6 +215,34 @@ class HabitDetailViewModel
         }
 
         private fun retryHabit() {
-            // TODO: API 연동
+            val habitId = uiState.value.habitId ?: return
+            val inputDuration = uiState.value.duration ?: return
+            val inputReward = rewardState.text.toString()
+
+            viewModelScope.launch {
+                habitRepository.retryFailedHabit(
+                    habitId = habitId,
+                    duration = inputDuration,
+                    reward = inputReward,
+                )
+                    .onSuccess {
+                        sendEffect(HabitDetailSideEffect.PopBackStack("멋져요! 습관 재도전을 시작했습니다."))
+                        updateState { copy(loadingState = Async.Success(Unit)) }
+                    }
+                    .onFailure { throwable ->
+                        when (throwable) {
+                            is HabitError.HabitNotFound -> {
+                                sendEffect(HabitDetailSideEffect.PopBackStack("이미 삭제된 습관입니다."))
+                            }
+
+                            is HabitError.RewardEmpty -> {
+                                sendEffect(HabitDetailSideEffect.ShowSnackbar("보상을 입력해주세요."))
+                            }
+
+                            is ApiError -> sendEffect(HabitDetailSideEffect.ShowSnackbar(throwable.snackbarMsg()))
+                        }
+                        updateState { copy(loadingState = Async.Init) }
+                    }
+            }
         }
     }

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailViewModel.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/detail/HabitDetailViewModel.kt
@@ -218,7 +218,11 @@ class HabitDetailViewModel
             if (uiState.value.loadingState is Async.Loading) return
             val habitId = uiState.value.habitId ?: return
             val inputDuration = uiState.value.duration ?: return
-            val inputReward = rewardState.text.toString()
+            val inputReward = when (screenType) {
+                HabitDetailScreenType.CHILD -> rewardState.text.toString()
+                HabitDetailScreenType.PARENT -> null
+                HabitDetailScreenType.IDLE -> null
+            }
 
             updateState { copy(loadingState = Async.Loading()) }
 

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListContract.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListContract.kt
@@ -16,6 +16,7 @@ data class HabitListUiState(
     val delRequestedId: Long? = null,
     val deleteState: Async<Unit> = Async.Init,
     val failedHabits: Async<List<HabitModel>> = Async.Init,
+    val isFailedHabitDelete: Boolean = false,
 ) : UiState {
     val showDeleteDialog = delRequestedId != null
 

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListContract.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListContract.kt
@@ -15,7 +15,7 @@ data class HabitListUiState(
     val habits: Async<List<HabitModel>> = Async.Init,
     val delRequestedId: Long? = null,
     val deleteState: Async<Unit> = Async.Init,
-    val retryHabits: Async<List<HabitModel>> = Async.Init,
+    val failedHabits: Async<List<HabitModel>> = Async.Init,
 ) : UiState {
     val showDeleteDialog = delRequestedId != null
 

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListScreen.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListScreen.kt
@@ -128,7 +128,7 @@ fun HabitListScreen(
         )
 
         HabitRetryList(
-            habits = uiState.retryHabits,
+            habits = uiState.failedHabits,
             onRetry = onRetryClick,
             onDelete = onDeleteClick,
             scrollState = scrollState,
@@ -153,7 +153,7 @@ private class HabitListScreenPreviewProvider : PreviewParameterProvider<HabitLis
     }
 
     override val values = sequenceOf(
-        HabitListUiState(habits = Async.Success(sampleHabits), retryHabits = Async.Empty),
+        HabitListUiState(habits = Async.Success(sampleHabits), failedHabits = Async.Empty),
         HabitListUiState(habits = Async.Success(emptyList())),
     )
 }

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListScreen.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListScreen.kt
@@ -60,7 +60,7 @@ fun HabitListRoute(
 
     if (uiState.showDeleteDialog) {
         HaebomDeleteDialog(
-            dialogType = DeleteDialogType.Habit,
+            dialogType = if (uiState.isFailedHabitDelete) DeleteDialogType.FailedHabit else DeleteDialogType.Habit,
             onConfirm = viewModel::onDeleteConfirm,
             onCancel = viewModel::onDeleteCancel,
             onDismiss = viewModel::onDeleteCancel,

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListScreen.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListScreen.kt
@@ -74,6 +74,7 @@ fun HabitListRoute(
         onCheckClick = viewModel::onCheckClick,
         onEditClick = viewModel::onEditClick,
         onDeleteClick = viewModel::onDeleteClick,
+        onFailedHabitDeleteClick = viewModel::onFailedHabitDeleteClick,
         onRetryClick = viewModel::onRetryClick,
         modifier = modifier,
     )
@@ -86,6 +87,7 @@ fun HabitListScreen(
     onCheckClick: (HabitModel) -> Unit,
     onEditClick: (HabitModel) -> Unit,
     onDeleteClick: (HabitModel) -> Unit,
+    onFailedHabitDeleteClick: (HabitModel) -> Unit,
     onRetryClick: (HabitModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -130,7 +132,7 @@ fun HabitListScreen(
         HabitRetryList(
             habits = uiState.failedHabits,
             onRetry = onRetryClick,
-            onDelete = onDeleteClick,
+            onDelete = onFailedHabitDeleteClick,
             scrollState = scrollState,
             modifier = Modifier
                 .fillMaxWidth()
@@ -170,6 +172,7 @@ private fun HabitListScreenPreview(
             onCheckClick = {},
             onEditClick = {},
             onDeleteClick = {},
+            onFailedHabitDeleteClick = {},
             onRetryClick = {},
         )
     }

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListViewModel.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListViewModel.kt
@@ -69,6 +69,7 @@ class HabitListViewModel
             message ?: return
             sendEffect(HabitListSideEffect.ShowSnackbar(message))
             getHabits()
+            getFailedHabits()
         }
 
         fun onCreateClick() {

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListViewModel.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListViewModel.kt
@@ -31,6 +31,7 @@ class HabitListViewModel
             updateState { copy(role = role) }
 
             getHabits()
+            getFailedHabits()
         }
 
         fun getHabits() {
@@ -47,6 +48,18 @@ class HabitListViewModel
                             updateState { copy(habits = Async.Success(prevData)) }
                         }
 
+                        if (it is ApiError) sendEffect(HabitListSideEffect.ShowSnackbar(it.snackbarMsg()))
+                    }
+            }
+        }
+
+        fun getFailedHabits() {
+            viewModelScope.launch {
+                habitRepository.getFailedHabits()
+                    .onSuccess {
+                        updateState { copy(failedHabits = if (it.isEmpty()) Async.Empty else Async.Success(it)) }
+                    }
+                    .onFailure {
                         if (it is ApiError) sendEffect(HabitListSideEffect.ShowSnackbar(it.snackbarMsg()))
                     }
             }

--- a/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListViewModel.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/habit/list/HabitListViewModel.kt
@@ -102,7 +102,11 @@ class HabitListViewModel
         }
 
         fun onDeleteClick(habit: HabitModel) {
-            updateState { copy(delRequestedId = habit.habitId, deleteState = Async.Init) }
+            updateState { copy(delRequestedId = habit.habitId, deleteState = Async.Init, isFailedHabitDelete = false) }
+        }
+
+        fun onFailedHabitDeleteClick(habit: HabitModel) {
+            updateState { copy(delRequestedId = habit.habitId, deleteState = Async.Init, isFailedHabitDelete = true) }
         }
 
         fun onDeleteConfirm() {
@@ -113,9 +117,17 @@ class HabitListViewModel
             viewModelScope.launch {
                 habitRepository.deleteHabit(habitId)
                     .onSuccess {
-                        updateState { copy(delRequestedId = null, deleteState = Async.Success(Unit)) }
-                        sendEffect(HabitListSideEffect.ShowSnackbar("습관이 삭제되었습니다."))
+                        val message = if (uiState.value.isFailedHabitDelete) "실패한 습관이 삭제되었습니다." else "습관이 삭제되었습니다."
+                        updateState {
+                            copy(
+                                delRequestedId = null,
+                                deleteState = Async.Success(Unit),
+                                isFailedHabitDelete = false,
+                            )
+                        }
+                        sendEffect(HabitListSideEffect.ShowSnackbar(message))
                         getHabits()
+                        getFailedHabits()
                     }.onFailure { throwable ->
                         when (throwable) {
                             is HabitError.HabitNotFound -> {

--- a/app/src/main/java/com/swyp/firsttodo/presentation/hamburger/share/ShareScreen.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/hamburger/share/ShareScreen.kt
@@ -99,7 +99,7 @@ fun ShareScreen(
         ) {
             CodeInputSection(
                 fieldState = codeFieldState,
-                modifier = Modifier.padding(bottom = 28.dp),
+                modifier = Modifier.padding(bottom = 3.dp),
                 onDoneAction = onDoneAction,
                 errorText = uiState.codeErrorText,
             )

--- a/app/src/main/java/com/swyp/firsttodo/presentation/todo/component/ScheduleBottomSheet.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/todo/component/ScheduleBottomSheet.kt
@@ -123,7 +123,7 @@ fun ScheduleBottomSheet(
                     onDismiss = onDismiss,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 28.dp),
+                        .padding(bottom = 16.dp),
                 )
 
                 TaskInputSection(

--- a/app/src/main/java/com/swyp/firsttodo/presentation/todo/component/TodoBottomSheet.kt
+++ b/app/src/main/java/com/swyp/firsttodo/presentation/todo/component/TodoBottomSheet.kt
@@ -138,7 +138,11 @@ fun TodoBottomSheet(
                     verticalAlignment = Alignment.Bottom,
                 ) {
                     if (isLoading) {
-                        Spacer(Modifier.size(161.dp, 29.dp).skeleton())
+                        Spacer(
+                            Modifier
+                                .size(161.dp, 29.dp)
+                                .skeleton(),
+                        )
                     } else {
                         Text(
                             text = sheetType.title,
@@ -159,7 +163,11 @@ fun TodoBottomSheet(
 
                 if (isLoading) {
                     Spacer(Modifier.height(2.dp))
-                    Spacer(Modifier.size(241.dp, 20.dp).skeleton())
+                    Spacer(
+                        Modifier
+                            .size(241.dp, 20.dp)
+                            .skeleton(),
+                    )
                 } else {
                     Text(
                         text = sheetType.description,
@@ -171,7 +179,11 @@ fun TodoBottomSheet(
                 Spacer(Modifier.height(28.dp))
 
                 if (isLoading) {
-                    Spacer(Modifier.size(56.dp, 26.dp).skeleton())
+                    Spacer(
+                        Modifier
+                            .size(56.dp, 26.dp)
+                            .skeleton(),
+                    )
                 } else {
                     Text(
                         text = "할 일",
@@ -183,21 +195,28 @@ fun TodoBottomSheet(
                 Spacer(Modifier.height(8.dp))
 
                 if (isLoading) {
-                    Spacer(Modifier.fillMaxWidth().height(48.dp).skeleton())
-                    Spacer(Modifier.height(20.dp))
+                    Spacer(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                            .skeleton(),
+                    )
                 } else {
                     HaebomMultiLineTextField(
                         fieldState = titleFieldState,
                         placeholder = "할 일을 입력해 주세요.",
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 20.dp),
+                            .fillMaxWidth(),
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     )
                 }
 
                 if (isLoading) {
-                    Spacer(Modifier.size(70.dp, 28.dp).skeleton())
+                    Spacer(
+                        Modifier
+                            .size(70.dp, 28.dp)
+                            .skeleton(),
+                    )
                 } else {
                     Text(
                         text = "카테고리",
@@ -215,14 +234,18 @@ fun TodoBottomSheet(
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         categories.forEach { _ ->
-                            Spacer(Modifier.size(64.dp, 32.dp).skeleton())
+                            Spacer(
+                                Modifier
+                                    .size(64.dp, 32.dp)
+                                    .skeleton(),
+                            )
                         }
                     }
 
-                    Spacer(Modifier.height(40.dp))
+                    Spacer(Modifier.height(20.dp))
                 } else {
                     Column(
-                        modifier = Modifier.padding(bottom = 40.dp),
+                        modifier = Modifier.padding(bottom = 20.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         TaskCategoryList(
@@ -235,7 +258,11 @@ fun TodoBottomSheet(
                 }
 
                 if (isLoading) {
-                    Spacer(Modifier.size(70.dp, 26.dp).skeleton())
+                    Spacer(
+                        Modifier
+                            .size(70.dp, 26.dp)
+                            .skeleton(),
+                    )
                 } else {
                     Text(
                         text = "색상 선택",
@@ -272,7 +299,12 @@ fun TodoBottomSheet(
                 }
 
                 if (isLoading) {
-                    Spacer(Modifier.fillMaxWidth().height(52.dp).skeleton())
+                    Spacer(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                            .skeleton(),
+                    )
                 } else {
                     HaebomLargeButton(
                         text = sheetType.btnText,


### PR DESCRIPTION
## Related issue 🛠️
- closed #83

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 실패한 습관 불러오기
- 습관 재도전
- 실패한 습관 삭제 (다이얼로그/토스트문구 일반 습관 삭제와 다름!)
- 텍스트필드 컴포넌트 변경에 따른 여백 조정

## Uncompleted Tasks 😅
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경 사항

* **새로운 기능**
  * 실패한 습관 목록 조회 및 재시도 기능 추가
  * 실패한 습관 삭제 시 전용 확인 대화상자 제공

* **버그 수정**
  * 보상(리워드) 미입력 시 오류 처리 개선
  * 습관 상세 화면의 제목 입력 필드 상태 관리 강화

* **스타일**
  * 습관 작성, 공유, 일정 화면의 레이아웃 간격 최적화
  * UI 구성 요소 포맷팅 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->