### PR TITLE
[Feat/#96] Fastlane 배포환경 분리

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,6 +53,7 @@ platform :android do
       groups: "swyp",
       release_notes: release_notes
     )
+    lane_context[:FIREBASE_UPLOADED] = true
 
     # 4. Discord 알림 전송
     UI.message("💬 3. 디스코드로 알림을 전송합니다...")
@@ -98,6 +99,7 @@ platform :android do
 
   error do |lane, exception|
     next unless lane_context[:VERSION_CODE_BUMPED]
+    next if lane_context[:FIREBASE_UPLOADED]
 
     gradle_file = "../app/build.gradle.kts"
     content = File.read(gradle_file)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,9 +13,10 @@ platform :android do
 
     gradle_file = "../app/build.gradle.kts"
     content = File.read(gradle_file)
-    new_content = content.gsub(/versionCode = (\d+)/) { "versionCode = #{$1.to_i + 1}" }
+    original_version_code = content.match(/versionCode = (\d+)/)[1].to_i
+    new_content = content.gsub(/versionCode = (\d+)/, "versionCode = #{original_version_code + 1}")
     File.open(gradle_file, "w") { |file| file.puts new_content }
-    UI.message("🚀 versionCode를 #{content.match(/versionCode = (\d+)/)[1].to_i + 1}로 올렸습니다!")
+    UI.message("🚀 versionCode를 #{original_version_code + 1}로 올렸습니다!")
 
     # 2. APK 빌드
     UI.message("📦 1. APK 빌드를 시작합니다...")
@@ -59,5 +60,16 @@ platform :android do
     Net::HTTP.post(uri, payload.to_json, "Content-Type" => "application/json")
 
     UI.success("🎉 QA 배포 및 디스코드 알림 전송이 완료되었습니다!")
+  end
+
+  error do |lane, exception|
+    gradle_file = "../app/build.gradle.kts"
+    content = File.read(gradle_file)
+    if content.match?(/versionCode = (\d+)/)
+      original_version_code = content.match(/versionCode = (\d+)/)[1].to_i - 1
+      restored_content = content.gsub(/versionCode = (\d+)/, "versionCode = #{original_version_code}")
+      File.open(gradle_file, "w") { |file| file.puts restored_content }
+      UI.error("❌ lane 실패로 versionCode를 #{original_version_code}으로 원복했습니다. (#{exception.message})")
+    end
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,6 +36,8 @@ platform :android do
     original_version_code = content.match(/versionCode = (\d+)/)[1].to_i
     new_content = content.gsub(/versionCode = (\d+)/, "versionCode = #{original_version_code + 1}")
     File.open(gradle_file, "w") { |file| file.puts new_content }
+    lane_context[:VERSION_CODE_BUMPED] = true
+    lane_context[:ORIGINAL_VERSION_CODE] = original_version_code
     UI.message("🚀 versionCode를 #{original_version_code + 1}로 올렸습니다!")
 
     version = get_version_info
@@ -92,13 +94,13 @@ platform :android do
   end
 
   error do |lane, exception|
+    next unless lane_context[:VERSION_CODE_BUMPED]
+
     gradle_file = "../app/build.gradle.kts"
     content = File.read(gradle_file)
-    if content.match?(/versionCode = (\d+)/)
-      original_version_code = content.match(/versionCode = (\d+)/)[1].to_i - 1
-      restored_content = content.gsub(/versionCode = (\d+)/, "versionCode = #{original_version_code}")
-      File.open(gradle_file, "w") { |file| file.puts restored_content }
-      UI.error("❌ lane 실패로 versionCode를 #{original_version_code}으로 원복했습니다. (#{exception.message})")
-    end
+    original = lane_context[:ORIGINAL_VERSION_CODE]
+    restored_content = content.gsub(/versionCode = \d+/, "versionCode = #{original}")
+    File.open(gradle_file, "w") { |file| file.puts restored_content }
+    UI.error("❌ lane 실패로 versionCode를 #{original}으로 원복했습니다. (#{exception.message})")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,6 +5,15 @@ require 'uri'
 require 'json'
 
 platform :android do
+  private_lane :get_version_info do
+    gradle_file = "../app/build.gradle.kts"
+    content = File.read(gradle_file)
+    {
+      version_code: content.match(/versionCode = (\d+)/)[1].to_i,
+      version_name: content.match(/versionName = "([^"]+)"/)[1]
+    }
+  end
+
   desc "QA 빌드 생성, Firebase 배포 및 디스코드 알림 전송"
   lane :qa do
 
@@ -17,6 +26,8 @@ platform :android do
     new_content = content.gsub(/versionCode = (\d+)/, "versionCode = #{original_version_code + 1}")
     File.open(gradle_file, "w") { |file| file.puts new_content }
     UI.message("🚀 versionCode를 #{original_version_code + 1}로 올렸습니다!")
+
+    version = get_version_info
 
     # 2. APK 빌드
     UI.message("📦 1. APK 빌드를 시작합니다...")
@@ -47,6 +58,10 @@ platform :android do
           description: "등록된 테스터 기기의 `App Tester` 앱 또는 메일함을 확인해 주세요.",
           color: 9739627,
           fields: [
+            {
+              name: "🏷️ 버전",
+              value: "#{version[:version_name]} (#{version[:version_code]})"
+            },
             {
               name: "📝 릴리즈 노트",
               value: release_notes

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,8 +14,19 @@ platform :android do
     }
   end
 
-  desc "QA 빌드 생성, Firebase 배포 및 디스코드 알림 전송"
-  lane :qa do
+  desc "QA 디버그 빌드 생성, Firebase 배포 및 디스코드 알림 전송"
+  lane :qa_debug do
+    deploy(build_type: "debug")
+  end
+
+  desc "QA 릴리즈 빌드 생성, Firebase 배포 및 디스코드 알림 전송"
+  lane :qa_release do
+    deploy(build_type: "release")
+  end
+
+  private_lane :deploy do |options|
+    build_type = options[:build_type]
+    is_release = build_type == "release"
 
     # 1. 릴리즈 노트 읽기 및 versionCode 자동 증가
     release_notes = File.read("release_notes.txt")
@@ -30,8 +41,8 @@ platform :android do
     version = get_version_info
 
     # 2. APK 빌드
-    UI.message("📦 1. APK 빌드를 시작합니다...")
-    gradle(task: "clean assembleRelease")
+    UI.message("📦 1. APK 빌드를 시작합니다... (#{build_type})")
+    gradle(task: "clean assemble#{build_type.capitalize}")
 
     # 3. Firebase App Distribution 등록
     UI.message("🔥 2. Firebase App Distribution에 업로드합니다...")
@@ -44,11 +55,11 @@ platform :android do
     # 4. Discord 알림 전송
     UI.message("💬 3. 디스코드로 알림을 전송합니다...")
 
-    webhook_url = ENV["DISCORD_WEBHOOK_URL"]
+    webhook_url = is_release ? ENV["DISCORD_RELEASE_WEBHOOK_URL"] : ENV["DISCORD_DEBUG_WEBHOOK_URL"]
     uri = URI(webhook_url)
-
-    # 디스코드에 보낼 메시지 포맷
     tags = ENV["DISCORD_USERS_TAG_ID"]
+    build_label = is_release ? "릴리즈" : "디버그"
+    embed_color = is_release ? 9739627 : 3447003
 
     payload = {
       content: "🚀 **Android QA 앱이 새로 배포되었습니다!** #{tags}",
@@ -56,8 +67,12 @@ platform :android do
         {
           title: "📱 Firebase App Distribution",
           description: "등록된 테스터 기기의 `App Tester` 앱 또는 메일함을 확인해 주세요.",
-          color: 9739627,
+          color: embed_color,
           fields: [
+            {
+              name: "🔧 빌드 타입",
+              value: build_label
+            },
             {
               name: "🏷️ 버전",
               value: "#{version[:version_name]} (#{version[:version_code]})"
@@ -71,10 +86,9 @@ platform :android do
       ]
     }
 
-    # HTTP 통신으로 디스코드에 쏘기
     Net::HTTP.post(uri, payload.to_json, "Content-Type" => "application/json")
 
-    UI.success("🎉 QA 배포 및 디스코드 알림 전송이 완료되었습니다!")
+    UI.success("🎉 QA #{build_label} 배포 및 디스코드 알림 전송이 완료되었습니다!")
   end
 
   error do |lane, exception|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -88,7 +88,10 @@ platform :android do
       ]
     }
 
-    Net::HTTP.post(uri, payload.to_json, "Content-Type" => "application/json")
+    response = Net::HTTP.post(uri, payload.to_json, "Content-Type" => "application/json")
+    unless response.is_a?(Net::HTTPSuccess)
+      UI.error("⚠️ 디스코드 알림 전송 실패 (HTTP #{response.code}): #{response.body}")
+    end
 
     UI.success("🎉 QA #{build_label} 배포 및 디스코드 알림 전송이 완료되었습니다!")
   end


### PR DESCRIPTION
## Related issue 🛠️
- closed #96 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- DEBUG/RELEASE 분기 처리 -> 디코 채널 분리
- 디코 메시지에 버전 필드 추가
- 실패 시 버전코드 원복 로직 추가

## Uncompleted Tasks 😅
- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 디버그 및 릴리스용 개별 QA 배포 경로가 추가되었습니다.
  * 빌드 타입에 따라 Discord 알림(웹훅, 색상, 성공 메시지)이 달라지며, 빌드 타입 및 버전 정보가 알림에 표시됩니다.

* **버그 수정**
  * 배포 실패 시 변경된 버전 코드가 자동으로 복원되도록 안전장치가 추가되었습니다.

* **작업**
  * QA 배포 흐름이 재구조화되어 빌드 유형별 처리 및 버전 관리를 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->